### PR TITLE
RD-29 update google cloud and docker setup in runners

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -27,14 +27,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
+      - id: "setup"
+        uses: "google-github-actions/setup-gcloud@master"
         with:
-          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+					project_id: ${{ secrets.PROJECT_ID }}
+					export_default_credentials: true
 
       - name: Docker configuration
         run: |-
-          echo ${{steps.auth.outputs.access_token}} | docker login -u oauth2accesstoken --password-stdin https://$GAR_LOCATION-docker.pkg.dev
+          gcloud auth configure-docker --quiet
 
       - name: Set up GKE credentials
         uses: google-github-actions/get-gke-credentials@v0


### PR DESCRIPTION
I've change the gcloud and docker setup to test because the runner docker couldn't log into the acr